### PR TITLE
Invalid roll numbers registration sorted

### DIFF
--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -11,6 +11,9 @@ from django.utils import timezone
 class UserManager(BaseUserManager):
     use_in_migrations = True
 
+    def normalize_roll_number(self, roll_number):
+        return roll_number.upper()
+
     def _create_user(self, roll_number, email, password, **extra_fields):
         """
         Create and save a user with the given roll number, email, and password.
@@ -18,6 +21,7 @@ class UserManager(BaseUserManager):
         if not roll_number:
             raise ValueError("The given roll number must be set")
         email = self.normalize_email(email)
+        roll_number = self.normalize_roll_number(roll_number)  
         user = self.model(roll_number=roll_number, email=email, **extra_fields)
         user.password = make_password(password)
         user.save(using=self._db)

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -20,6 +20,15 @@ class RegisterUserSerializer(serializers.ModelSerializer):
 
         return password
 
+    
+    def validate_roll_number(self, roll_number):
+
+        if not is_valid_roll_number(roll_number):
+            raise serializers.ValidationError("Invalid roll number format")
+
+        return roll_number
+
+
     def create(self, validated_data):
         """
         Override the create mehtod with objects.create_user,
@@ -34,3 +43,9 @@ class UserAutoCompleteSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ["id", "roll_number", "name"]
+
+
+
+def is_valid_roll_number(roll_number):
+    allowed_prefixes = ['18', '19', '20', '21', '22', '23']
+    return len(roll_number) >= 7 and roll_number[:2] in allowed_prefixes


### PR DESCRIPTION
Created a function in serialisers.py which checks the format of roll no starting from [18,19,20,21,22,23] as well as length and other roll no characteristics before creating a user object\
![WhatsApp Image 2023-10-29 at 1 43 58 AM-2](https://github.com/wncc/SoC-Portal/assets/118129263/39f6130e-6bf0-4fca-9eb5-46582c9d854f)
![WhatsApp Image 2023-10-29 at 1 43 58 AM](https://github.com/wncc/SoC-Portal/assets/118129263/415e8ffd-0582-48ed-9535-74a056d03d97)
